### PR TITLE
Update package versions

### DIFF
--- a/src/Extensions/Spectre.Console.Extensions.Markup/Spectre.Console.Extensions.Markup.csproj
+++ b/src/Extensions/Spectre.Console.Extensions.Markup/Spectre.Console.Extensions.Markup.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.40.0" />
+    <PackageReference Include="Markdig" Version="0.41.1" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
   </ItemGroup>

--- a/src/Extensions/Spectre.Console.Extensions.Markup/Spectre.Console.Extensions.Markup.csproj
+++ b/src/Extensions/Spectre.Console.Extensions.Markup/Spectre.Console.Extensions.Markup.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.41.1" />
+    <PackageReference Include="Markdig" Version="0.41.2" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
   </ItemGroup>

--- a/src/Spectre.Console.CSharp/Spectre.Console.CSharp.csproj
+++ b/src/Spectre.Console.CSharp/Spectre.Console.CSharp.csproj
@@ -9,13 +9,13 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <IsAotCompatible Condition="'$(TargetFramework)' != 'netstandard2.0'" >true</IsAotCompatible>
+    <IsAotCompatible Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsAotCompatible>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Bump Markdig version from 0.40.0 to 0.41.1 in Spectre.Console.Extensions.Markup.csproj.
- Adjust formatting of IsAotCompatible element in Spectre.Console.CSharp.csproj for consistency.
- Upgrade Microsoft.CodeAnalysis.Common and Microsoft.CodeAnalysis.CSharp from 4.13.0 to 4.14.0 in Spectre.Console.CSharp.csproj.